### PR TITLE
Typed Context

### DIFF
--- a/src/State.ts
+++ b/src/State.ts
@@ -10,8 +10,11 @@ import { kebabCase } from 'lodash';
 import StateMachine from './StateMachine';
 import Transition from './Transition';
 
+export type TEntryActionFn<TContext = any> = (state: State<TContext>, context?: TContext) => void;
+export type TExitActionFn<TContext = any> = (state: State<TContext>, context?: TContext) => boolean;
+
 /** This class defines a new state for the state machine. */
-export default class State {
+export default class State <TContext = any>{
   /**
    * Instantiates a new state machine.
    * @param stateMachine The state machine this state is associated with.
@@ -54,10 +57,10 @@ export default class State {
   }
 
   /** An optional action that is invoked whenever the state machine enters this state. */
-  public entryAction?: Function = undefined;
+  public entryAction?: TEntryActionFn<TContext>;
 
   /** An optional action that is invoked whenever the state machine exits this state. */
-  public exitAction?: Function = undefined;
+  public exitAction?: TExitActionFn<TContext>;
 
   //-----------------------------------------------------------------------
   // METHODS

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -6,7 +6,7 @@
  * @version 1.0.0
  */
 
-import State from './State';
+import State, { TEntryActionFn, TExitActionFn } from './State';
 import Transition from './Transition';
 import { kebabCase } from 'lodash';
 
@@ -16,13 +16,13 @@ import { kebabCase } from 'lodash';
  * of each state and enforces transition rules. An application can have
  * multiple state machines.
  */
-export default class StateMachine {
+export default class StateMachine<TContext = any> {
   /**
    * Instantiates a new state machine.
    * @param name A unique identifier for this state machine.
    * @param [context] An optional context that will automatically be sent to every state action.
    */
-  public constructor(name: string, context?: any) {
+  public constructor(name: string, context?: TContext) {
     this._name = name;
     this._context = context;
   }
@@ -31,7 +31,7 @@ export default class StateMachine {
   private _name: string;
 
   /** An optional context that will automatically be sent to every state action. */
-  private _context?: any;
+  private _context?: TContext;
 
   /** A collection of all possible global machine transitions between states. */
   private _transitions: Map<string, Transition> = new Map();
@@ -40,13 +40,13 @@ export default class StateMachine {
   private _states: Map<string, State> = new Map();
 
   /** The state that should be entered when the machine is first started. */
-  private _startState?: State = undefined;
+  private _startState?: State<TContext> = undefined;
 
   /** The current state of the machine. */
-  private _currentState?: State = undefined;
+  private _currentState?: State<TContext> = undefined;
 
   /** The previous state of the machine; undefiend if there is no previous state. */
-  private _previousState?: State = undefined;
+  private _previousState?: State<TContext> = undefined;
 
   /** A unique identifier for this state machine. */
   public get name(): string {
@@ -173,7 +173,12 @@ export default class StateMachine {
    * @param [exitAction] An optional action that fires whenever the state machine exits this state.
    * @returns The newly created state.
    */
-  public createState(id: string, isComplete: boolean = false, entryAction: Function | undefined = undefined, exitAction: Function | undefined = undefined): State {
+  public createState(
+    id: string,
+    isComplete: boolean = false,
+    entryAction?: TEntryActionFn<TContext>,
+    exitAction?: TExitActionFn<TContext>,
+  ): State<TContext> {
     const state = new State(this, id, isComplete);
     state.entryAction = entryAction;
     state.exitAction = exitAction;

--- a/tests/fusium.spec.ts
+++ b/tests/fusium.spec.ts
@@ -2,6 +2,7 @@
 
 import * as chai from 'chai';
 import { State, StateMachine, Transition } from '../src/index';
+import { TEntryActionFn, TExitActionFn } from '../src/State';
 
 const expect = chai.expect;
 describe('test states', (): void => {
@@ -200,22 +201,27 @@ describe('test the state machine', (): void => {
   });
 
   it('should provide context to all actions', (): void => {
-    const context: object = {
+    type ContextType = {
+      testEntry: string;
+      testExit: string;
+    };
+    const context = {
       testEntry: 'test123',
       testExit: 'test456'
     };
 
-    const entryAction: Function = (state: State, context: any): void => {
+    const entryAction: TEntryActionFn<ContextType> = (state, context): void => {
       expect(context).to.exist;
-      expect(context.testEntry).to.equal('test123');
+      expect(context?.testEntry).to.equal('test123');
     };
 
-    const exitAction: Function = (state: State, context: any): void => {
+    const exitAction: TExitActionFn<ContextType> = (state, context): boolean => {
       expect(context).to.exist;
-      expect(context.testExit).to.equal('test456');
+      expect(context?.testExit).to.equal('test456');
+      return true;
     };
 
-    const stateMachine: StateMachine = new StateMachine('my first state machine', context);
+    const stateMachine: StateMachine = new StateMachine<ContextType>('my first state machine', context);
     const s1: State = stateMachine.createState('my first state', false, entryAction, exitAction);
     const s2: State = stateMachine.createState('my second state', true);
     s1.addTransition('next', s2);


### PR DESCRIPTION
Adds the ability to specify an explicit type for a `StateMachine`'s context.  The [the tests](tests/fusium.spec.ts) for an examples of usage.

This does not break the current API as the `TContext` generic will default to `any` if not provided.